### PR TITLE
Updated ReadMe for Build version Android-P

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ If you encounter issues using or integrating this plugin, please file a support 
     <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 ```
 
+Note :-  If the Build vesion is Android P then please Add following Permission 
+```java
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
+```
+
+
 ### Android Test Devices
 
 Add Marketo Activity in manifest file inside application tag.


### PR DESCRIPTION
If the Application build version is Android P, customer needs to add "FOREGROUND_SERVICE" permission